### PR TITLE
Add serde derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ ctrlc = { version = "3.1.4", optional = true }
 [features]
 default = []
 telemetry = ["rusty_dashed", "open", "serde", "serde_derive", "serde_json"]
+with_serde = ["serde", "serde_derive"]
 openai = ["cpython", "python3-sys", "ctrlc"]
 ctrnn_telemetry = []
 
@@ -42,7 +43,14 @@ required-features = ["cpython"]
 name = "simple_sample"
 
 [[example]]
+name = "serde_sample"
+
+[[example]]
 name = "function_approximation"
 
 [[example]]
 name = "ctrnn"
+
+[dev-dependencies]
+ctrlc = "3.1.4"
+serde_json = "1.0"

--- a/examples/serde_sample.rs
+++ b/examples/serde_sample.rs
@@ -1,0 +1,101 @@
+extern crate rand;
+extern crate rustneat;
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::sync::{Arc, Mutex};
+
+use rustneat::Environment;
+use rustneat::Organism;
+use rustneat::Population;
+
+#[cfg(feature = "telemetry")]
+mod telemetry_helper;
+
+struct XORClassification;
+
+impl Environment for XORClassification {
+    fn test(&self, organism: &mut Organism) -> f64 {
+        let mut output = vec![0f64];
+        let mut distance: f64;
+        organism.activate(vec![0f64, 0f64], &mut output);
+        distance = (0f64 - output[0]).powi(2);
+        organism.activate(vec![0f64, 1f64], &mut output);
+        distance += (1f64 - output[0]).powi(2);
+        organism.activate(vec![1f64, 0f64], &mut output);
+        distance += (1f64 - output[0]).powi(2);
+        organism.activate(vec![1f64, 1f64], &mut output);
+        distance += (0f64 - output[0]).powi(2);
+
+        let fitness = 16f64 / (1f64 + distance);
+
+        fitness
+    }
+}
+
+const POPULATION_PATH: &str = "population.json";
+
+fn main() {
+    let lock = Arc::new(Mutex::new(()));
+    let l = Arc::clone(&lock);
+    ctrlc::set_handler(move || {
+        let _guard = l.lock().unwrap();
+        std::process::exit(0);
+    })
+    .unwrap();
+
+    #[cfg(feature = "telemetry")]
+    telemetry_helper::enable_telemetry("?max_fitness=18", true);
+
+    #[cfg(feature = "telemetry")]
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+
+    let mut population = match File::open(POPULATION_PATH) {
+        Ok(file) => match serde_json::from_reader(BufReader::new(file)) {
+            Ok(population) => {
+                println!("Loaded population from {}", POPULATION_PATH);
+                population
+            }
+            Err(err) => {
+                eprintln!("Error parsing {}: {}", POPULATION_PATH, err);
+                return;
+            }
+        },
+        Err(err) => {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                Population::create_population(150)
+            } else {
+                eprintln!("Error reading {}: {}", POPULATION_PATH, err);
+                return;
+            }
+        }
+    };
+
+    let mut environment = XORClassification;
+    let mut champion: Option<Organism> = None;
+    while champion.is_none() {
+        population.evolve();
+        population.evaluate_in(&mut environment);
+        {
+            let _guard = lock.lock().unwrap();
+            match File::create(POPULATION_PATH) {
+                Ok(file) => {
+                    if let Err(err) = serde_json::to_writer(BufWriter::new(file), &population) {
+                        eprintln!("Error serializing to {}: {}", POPULATION_PATH, err);
+                        return;
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Error writing to {}: {}", POPULATION_PATH, err);
+                    return;
+                }
+            }
+        }
+        for organism in &population.get_organisms() {
+            if organism.fitness > 15.5f64 {
+                champion = Some(organism.clone());
+            }
+        }
+    }
+    println!("{}", serde_json::to_string_pretty(&champion.unwrap()).unwrap());
+}

--- a/src/gene.rs
+++ b/src/gene.rs
@@ -5,7 +5,8 @@ use std::cmp::Ordering;
 
 /// A connection Gene
 #[derive(Debug, Copy, Clone)]
-#[cfg_attr(feature = "telemetry", derive(Serialize))]
+#[cfg_attr(any(feature = "telemetry", feature = "with_serde"), derive(Serialize))]
+#[cfg_attr(feature = "with_serde", derive(Deserialize))]
 pub struct Gene {
     in_neuron_id: usize,
     out_neuron_id: usize,

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -6,6 +6,7 @@ use std::cmp;
 /// Vector of Genes
 /// Holds a count of last neuron added, similar to Innovation number
 #[derive(Default, Debug, Clone)]
+#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 pub struct Genome {
     genes: Vec<Gene>,
     last_neuron_id: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate num_cpus;
 extern crate rand;
 extern crate rulinalg;
 
-#[cfg(feature = "telemetry")]
+#[cfg(any(feature = "telemetry", feature = "with_serde"))]
 #[macro_use]
 extern crate serde_derive;
 

--- a/src/organism.rs
+++ b/src/organism.rs
@@ -6,6 +6,7 @@ use std::cmp;
 /// Also maitain a fitenss measure of the organism
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 pub struct Organism {
     pub genome: Genome,
     pub fitness: f64,

--- a/src/population.rs
+++ b/src/population.rs
@@ -15,6 +15,7 @@ use species_evaluator::SpeciesEvaluator;
 
 /// All species in the network
 #[derive(Debug)]
+#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 pub struct Population {
     /// container of species
     pub species: Vec<Specie>,

--- a/src/specie.rs
+++ b/src/specie.rs
@@ -7,6 +7,7 @@ use rand::Rng;
 
 /// A species (several organisms) and associated fitnesses
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 pub struct Specie {
     representative: Genome,
     average_fitness: f64,


### PR DESCRIPTION
Adds serde derives for `Serialize` and `Deserialize`, which can be enabled through the `with_serde` feature. Intended for being able to save and restore the population to pause and resume evolution, as well as saving the best genes for later use. Adds an example for this use case. Let me know if there are issues.